### PR TITLE
Real Simple HTTP server for Prometheus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,15 +134,18 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "argh",
+ "ascii",
  "ctrlc",
  "env_logger",
  "hex",
  "itertools",
+ "jod-thread",
  "log",
- "prometheus_exporter",
+ "prometheus",
  "rand",
  "serde",
  "serde_json",
+ "tiny_http",
  "ureq",
 ]
 
@@ -256,6 +259,12 @@ name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
+
+[[package]]
+name = "jod-thread"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b23360e99b8717f20aaa4598f5a6541efbe30630039fbc7706cf954a87947ae"
 
 [[package]]
 name = "js-sys"
@@ -393,30 +402,24 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8425533e7122f0c3cc7a37e6244b16ad3a2cc32ae7ac6276e2a75da0d9c200d"
+checksum = "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c"
 dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "memchr",
  "parking_lot",
- "regex",
+ "protobuf",
  "thiserror",
 ]
 
 [[package]]
-name = "prometheus_exporter"
-version = "0.8.0"
-source = "git+https://github.com/insipx/prometheus_exporter?branch=update-tiny-http#936e785ac1c48b79cd85c9c32ad8adc4b7417792"
-dependencies = [
- "ascii",
- "lazy_static",
- "log",
- "prometheus",
- "thiserror",
- "tiny_http",
-]
+name = "protobuf"
+version = "2.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f72884896d22e0da0e5b266cb9a780b791f6c3b2f5beab6368d6cd4f0dbb86"
 
 [[package]]
 name = "quote"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,12 @@ ctrlc = "3.1.7"
 env_logger = "0.8.3"
 hex = "0.4.2"
 log = "0.4.14"
-prometheus_exporter = { git = "https://github.com/insipx/prometheus_exporter", branch = "update-tiny-http" }
+prometheus = "0.12"
+tiny_http = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.61"
 ureq = { version = "2.0.1", features = ["json"] }
 rand = "0.8.3"
 itertools = "0.10.0"
+jod-thread = "0.1.2"
+ascii = "1.0.0"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -84,7 +84,7 @@ pub struct Services {
 pub struct Daemon {
 	#[argh(option)]
 	/// frequency to update jaeger metrics in milliseconds.
-	pub frequency: Option<usize>,
+	pub frequency: Option<u64>,
 	#[argh(option, default = "default_port()")]
 	/// port to expose prometheus metrics at. Default 9186
 	pub port: usize,
@@ -156,7 +156,6 @@ fn services(app: &App, _: &Services) -> Result<(), Error> {
 /// Daemonize collecting Jaeger Metrics every few seconds, reporting everything to Prometheus.
 fn daemonize(app: &App, daemon: &Daemon) -> Result<(), Error> {
 	let api = JaegerApi::new(&app.url);
-	println!("Launching Jaeger Collector daemon!");
 	let mut daemon = PrometheusDaemon::new(daemon, &api, app)?;
 	daemon.start()?;
 	Ok(())

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -19,11 +19,12 @@
 use crate::{
 	api::JaegerApi,
 	cli::{App, Daemon},
+	http::Server,
 	primitives::{Span, TraceObject},
 };
 use anyhow::{bail, Error};
 use itertools::Itertools;
-use prometheus_exporter::prometheus::{register_gauge, register_histogram, Gauge, Histogram};
+use prometheus::{register_gauge, register_histogram, Gauge, Histogram};
 use std::{
 	collections::HashMap,
 	convert::TryFrom,
@@ -59,12 +60,15 @@ pub struct PrometheusDaemon<'a> {
 	api: &'a JaegerApi<'a>,
 	app: &'a App,
 	metrics: Metrics,
+	/// frequency to update metrics in milliseconds
+	frequency: u64,
 }
 
 impl<'a> PrometheusDaemon<'a> {
 	pub fn new(daemon: &'a Daemon, api: &'a JaegerApi, app: &'a App) -> Result<Self, Error> {
 		let metrics = Metrics::new(daemon)?;
-		Ok(Self { port: daemon.port, api, app, metrics })
+		let frequency = daemon.frequency.unwrap_or(1000);
+		Ok(Self { port: daemon.port, api, app, metrics, frequency })
 	}
 
 	pub fn start(&mut self) -> Result<(), Error> {
@@ -72,14 +76,14 @@ impl<'a> PrometheusDaemon<'a> {
 		let addr: SocketAddr = addr_raw.parse().expect("can not parse listen addr");
 
 		// start the exporter and update metrics every five seconds
-		let exporter = prometheus_exporter::start(addr).expect("can not start exporter");
-
+		let exporter = Server::start(addr).expect("can not start exporter server");
+		log::info!("Hello");
 		let running = Arc::new(AtomicBool::new(true));
 		let r = running.clone();
 		ctrlc::set_handler(move || r.store(false, Ordering::SeqCst)).expect("Could not set the Ctrl-C handler.");
 
 		while running.load(Ordering::SeqCst) {
-			let _guard = exporter.wait_duration(Duration::from_millis(1000));
+			std::thread::sleep(Duration::from_millis(self.frequency));
 			self.metrics.clear();
 			let now = std::time::Instant::now();
 			let json = self.api.traces(self.app)?;
@@ -90,6 +94,8 @@ impl<'a> PrometheusDaemon<'a> {
 				break;
 			}
 		}
+		exporter.stop();
+
 		Ok(())
 	}
 

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,0 +1,83 @@
+// Copyright 2021 Parity Technologies (UK) Ltd.
+// This file is part of dot-jaeger.
+
+// dot-jaeger is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// dot-jaeger is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with dot-jaeger.  If not, see <http://www.gnu.org/licenses/>.
+
+//! The HTTP Server that responds to Prometheus Requests
+
+use anyhow::{anyhow, Context as _, Error};
+use ascii::AsciiString;
+use prometheus::{Encoder as _, TextEncoder};
+use std::{net::SocketAddr, sync::Arc};
+use tiny_http::{Header, Request, Response, Server as TinyServer};
+
+pub struct Server {
+	handle: jod_thread::JoinHandle<()>,
+	server: Arc<TinyServer>,
+}
+
+impl Server {
+	pub fn start(addr: SocketAddr) -> Result<Self, Error> {
+		let server = Arc::new(TinyServer::http(addr).map_err(|e| anyhow!(e.to_string()))?);
+		let threaded_server = server.clone();
+		log::info!("exporting metrics to http://{}/metrics", addr);
+
+		let handle = jod_thread::spawn(move || {
+			if let Err(e) = Self::request_handler(&threaded_server) {
+				log::error!("{}", e);
+			}
+		});
+
+		Ok(Self { handle, server })
+	}
+
+	fn request_handler(server: &TinyServer) -> Result<(), Error> {
+		for request in server.incoming_requests() {
+			match request.url() {
+				"/metrics" => Self::handle_metrics(request)?,
+				_ => Self::handle_redirect(request)?,
+			};
+		}
+		Ok(())
+	}
+
+	fn handle_metrics(request: Request) -> Result<(), Error> {
+		let encoder = TextEncoder::new();
+		let metrics = prometheus::gather();
+		let mut buffer = vec![];
+
+		encoder.encode(&metrics, &mut buffer)?;
+
+		let response = Response::from_data(buffer);
+		request.respond(response).with_context(|| format!("Failed to respond to Prometheus request for metrics"))?;
+		Ok(())
+	}
+
+	fn handle_redirect(request: Request) -> Result<(), Error> {
+		let response = Response::from_string("the endpoint you probably want is `/metrics` ಠ_ಠ")
+			.with_status_code(301)
+			.with_header(Header {
+				field: "Location".parse().expect("Can not parse location header. This should never fail"),
+				value: AsciiString::from_ascii("/metrics")
+					.expect("Could not parse header value. This should never fail."),
+			});
+		request.respond(response)?;
+		Ok(())
+	}
+
+	pub fn stop(self) {
+		self.server.unblock();
+		self.handle.join();
+	}
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -56,9 +56,7 @@ impl Server {
 		let encoder = TextEncoder::new();
 		let metrics = prometheus::gather();
 		let mut buffer = vec![];
-
 		encoder.encode(&metrics, &mut buffer)?;
-
 		let response = Response::from_data(buffer);
 		request.respond(response).with_context(|| "Failed to respond to Prometheus request for metrics".to_string())?;
 		Ok(())

--- a/src/http.rs
+++ b/src/http.rs
@@ -60,12 +60,12 @@ impl Server {
 		encoder.encode(&metrics, &mut buffer)?;
 
 		let response = Response::from_data(buffer);
-		request.respond(response).with_context(|| format!("Failed to respond to Prometheus request for metrics"))?;
+		request.respond(response).with_context(|| "Failed to respond to Prometheus request for metrics".to_string())?;
 		Ok(())
 	}
 
 	fn handle_redirect(request: Request) -> Result<(), Error> {
-		let response = Response::from_string("the endpoint you probably want is `/metrics` ಠ_ಠ")
+		let response = Response::from_string("the endpoint you probably want is `/metrics` ಠ_ಠ\n")
 			.with_status_code(301)
 			.with_header(Header {
 				field: "Location".parse().expect("Can not parse location header. This should never fail"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use env_logger::{Builder, Env};
 mod api;
 mod cli;
 mod daemon;
+mod http;
 mod primitives;
 
 fn main() -> Result<(), Error> {


### PR DESCRIPTION
just serves the /metrics endpoint and redirects if anything but /metrics is used

This definitely helped with the response time of dot-jeager

closes #15 